### PR TITLE
Install playwright and manage manual login

### DIFF
--- a/bac_hunter/http_client.py
+++ b/bac_hunter/http_client.py
@@ -134,8 +134,8 @@ class HttpClient:
         if not self._session_mgr:
             return False
         try:
-            # Delegate to session manager for interactive login and persistence
-            return bool(self._session_mgr.open_browser_login(url))
+            # Block until authentication succeeds so scanning continues authenticated
+            return bool(self._session_mgr.ensure_logged_in(url))
         except Exception:
             return False
 


### PR DESCRIPTION
Synchronize Playwright browser installation and block scan execution until manual user login is complete and authentication tokens are captured.

Previously, `smart-scan` and `smart-auto` commands could fail to open a browser for manual login due to asynchronous Playwright browser installation, and the scan would proceed without ensuring user authentication. This led to unauthenticated scans or errors. The changes ensure that Playwright browsers are installed synchronously, and the scan is paused until a robust set of heuristics (URL change, cookies, web storage tokens) confirms the user has successfully logged in, guaranteeing an authenticated session before proceeding.

---
<a href="https://cursor.com/background-agent?bcId=bc-81f8476b-ef5d-4e5f-8492-6636b5ecb2f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81f8476b-ef5d-4e5f-8492-6636b5ecb2f0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

